### PR TITLE
Force the search to use only the name of the file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ master_doc = 'index'
 project = u'tailon'
 copyright = u'2013-2017, Georgi Valkov'
 
-release = '1.3.0-criteo.7'
+release = '1.3.0-criteo.8'
 version = release
 
 exclude_patterns = ['_build']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ PyYAML >= 3.11
 cssmin >= 0.2.0
 webassets >= 0.12.1
 bumpversion >= 0.5.3
+pytest-runner >= 4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0-criteo.7
+current_version = 1.3.0-criteo.8
 message = Bump version: {current_version} -> {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-criteo.(?P<criteo_minor>\d+)
 serialize = {major}.{minor}.{patch}-criteo.{criteo_minor}

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
 
 kw = {
     'name':             'tailon',
-    'version':          '1.3.0-criteo.7',
+    'version':          '1.3.0-criteo.8',
     'description':      'Webapp for looking at and searching through log files',
     'long_description': open('README.rst').read(),
     'author':           'Georgi Valkov',

--- a/tailon/__init__.py
+++ b/tailon/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.0-criteo.7'
+__version__ = '1.3.0-criteo.8'

--- a/tailon/utils.py
+++ b/tailon/utils.py
@@ -125,7 +125,7 @@ class FileLister:
 def path_from_app(dirs, app):
     app_dir = []
     for dirname in dirs:
-        found = re.search('.*%s' %app, dirname)
+        found = re.search('.*\/%s' %app, dirname)
         if found:
             app_dir.append(found.group())
     if len(app_dir) > 1:


### PR DESCRIPTION
Avoid to have collision when searching with a filename. For example, searching for bar would collision with
some/path/foo_bar
some/path/bar